### PR TITLE
String operators and builtin functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,13 @@ name = "evalexpr"
 path = "src/lib.rs"
 
 [dependencies]
+regex = { version = "1", optional = true}
 serde = { version = "1", optional = true}
 serde_derive = { version = "1", optional = true}
 
 [features]
 serde_support = ["serde", "serde_derive"]
+regex_support = ["regex"]
 
 [dev-dependencies]
 ron = "0.4"

--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ This crate offers a set of builtin functions.
 |------------|-----------------|-------------|
 | min | >= 1 | Returns the minimum of the arguments |
 | max | >= 1 | Returns the maximum of the arguments |
+| downcase | 1 | Returns lower-case version of string |
+| len | 1 | Return the character length of string argument |
+| match | 2 | Returns true if first string argument matches regex in second |
+| replace | 3 | Returns string with matches replaced by third argument |
+| trim | 1 | Strips whitespace from start and end of string |
+| upcase | 1 | Returns upper-case version of string |
 
 The `min` and `max` functions can deal with a mixture of integer and floating point arguments.
 They return the result as the type it was passed into the function.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ This crate offers a set of builtin functions.
 | upcase | 1 | Returns upper-case version of string |
 
 The `min` and `max` functions can deal with a mixture of integer and floating point arguments.
-They return the result as the type it was passed into the function.
+They return the result as the type it was passed into the function. The regex functions require
+feature flag `regex_support`.
 
 ### Values
 

--- a/README.md
+++ b/README.md
@@ -214,12 +214,12 @@ This crate offers a set of builtin functions.
 |------------|-----------------|-------------|
 | min | >= 1 | Returns the minimum of the arguments |
 | max | >= 1 | Returns the maximum of the arguments |
-| downcase | 1 | Returns lower-case version of string |
+| to_lowercase | 1 | Returns lower-case version of string |
 | len | 1 | Return the character length of string argument |
 | regex_matches | 2 | Returns true if first string argument matches regex in second |
 | regex_replace | 3 | Returns string with matches replaced by third argument |
 | trim | 1 | Strips whitespace from start and end of string |
-| upcase | 1 | Returns upper-case version of string |
+| to_uppercase | 1 | Returns upper-case version of string |
 
 The `min` and `max` functions can deal with a mixture of integer and floating point arguments.
 They return the result as the type it was passed into the function. The regex functions require

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ This crate offers a set of builtin functions.
 | max | >= 1 | Returns the maximum of the arguments |
 | downcase | 1 | Returns lower-case version of string |
 | len | 1 | Return the character length of string argument |
-| match | 2 | Returns true if first string argument matches regex in second |
-| replace | 3 | Returns string with matches replaced by third argument |
+| regex_matches | 2 | Returns true if first string argument matches regex in second |
+| regex_replace | 3 | Returns string with matches replaced by third argument |
 | trim | 1 | Strips whitespace from start and end of string |
 | upcase | 1 | Returns upper-case version of string |
 

--- a/README.md
+++ b/README.md
@@ -214,12 +214,12 @@ This crate offers a set of builtin functions.
 |------------|-----------------|-------------|
 | min | >= 1 | Returns the minimum of the arguments |
 | max | >= 1 | Returns the maximum of the arguments |
-| to_lowercase | 1 | Returns lower-case version of string |
 | len | 1 | Return the character length of string argument |
-| regex_matches | 2 | Returns true if first string argument matches regex in second |
-| regex_replace | 3 | Returns string with matches replaced by third argument |
-| trim | 1 | Strips whitespace from start and end of string |
-| to_uppercase | 1 | Returns upper-case version of string |
+| str::regex_matches | 2 | Returns true if first string argument matches regex in second |
+| str::regex_replace | 3 | Returns string with matches replaced by third argument |
+| str::to_lowercase | 1 | Returns lower-case version of string |
+| str::to_uppercase | 1 | Returns upper-case version of string |
+| str::trim | 1 | Strips whitespace from start and end of string |
 
 The `min` and `max` functions can deal with a mixture of integer and floating point arguments.
 They return the result as the type it was passed into the function. The regex functions require

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -24,6 +24,9 @@ impl fmt::Display for EvalexprError {
             ExpectedNumber { actual } => {
                 write!(f, "Expected a Value::Number, but got {:?}.", actual)
             },
+            ExpectedNumberOrString { actual } => {
+                write!(f, "Expected a Value::Number or a Value::String, but got {:?}.", actual)
+            },
             ExpectedBoolean { actual } => {
                 write!(f, "Expected a Value::Boolean, but got {:?}.", actual)
             },

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -84,6 +84,7 @@ impl fmt::Display for EvalexprError {
             ModulationError { dividend, divisor } => {
                 write!(f, "Error modulating {} % {}", dividend, divisor)
             },
+            InvalidRegex { regex, message } => write!(f, "Regular expression {} is invalid: {}", regex, message),
             ContextNotManipulable => write!(f, "Cannot manipulate context"),
             IllegalEscapeSequence(string) => write!(f, "Illegal escape sequence: {}", string),
             CustomMessage(message) => write!(f, "Error: {}", message),

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -84,7 +84,7 @@ impl fmt::Display for EvalexprError {
             ModulationError { dividend, divisor } => {
                 write!(f, "Error modulating {} % {}", dividend, divisor)
             },
-            InvalidRegex { regex, message } => write!(f, "Regular expression {} is invalid: {}", regex, message),
+            InvalidRegex { regex, message } => write!(f, "Regular expression {:?} is invalid: {:?}", regex, message),
             ContextNotManipulable => write!(f, "Cannot manipulate context"),
             IllegalEscapeSequence(string) => write!(f, "Illegal escape sequence: {}", string),
             CustomMessage(message) => write!(f, "Error: {}", message),

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -340,7 +340,7 @@ pub fn expect_number(actual: &Value) -> EvalexprResult<()> {
     }
 }
 
-/// Returns Ok(()) if the given value is a string or a numeric
+/// Returns `Ok(())` if the given value is a string or a numeric
 pub fn expect_number_or_string(actual: &Value) -> EvalexprResult<()> {
     match actual {
         Value::String(_) | Value::Float(_) | Value::Int(_) => Ok(()),

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -56,6 +56,13 @@ pub enum EvalexprError {
         actual: Value,
     },
 
+    /// A numeric or string value was expected.
+    /// Numeric values are the variants `Value::Int` and `Value::Float`.
+    ExpectedNumberOrString {
+        /// The actual value.
+        actual: Value,
+    },
+
     /// A boolean value was expected.
     ExpectedBoolean {
         /// The actual value.
@@ -204,6 +211,11 @@ impl EvalexprError {
         EvalexprError::ExpectedNumber { actual }
     }
 
+    /// Constructs `Error::ExpectedNumberOrString{actual}`.
+    pub fn expected_number_or_string(actual: Value) -> Self {
+        EvalexprError::ExpectedNumberOrString { actual }
+    }
+
     /// Constructs `Error::ExpectedBoolean{actual}`.
     pub fn expected_boolean(actual: Value) -> Self {
         EvalexprError::ExpectedBoolean { actual }
@@ -312,6 +324,14 @@ pub fn expect_number(actual: &Value) -> EvalexprResult<()> {
     match actual {
         Value::Float(_) | Value::Int(_) => Ok(()),
         _ => Err(EvalexprError::expected_number(actual.clone())),
+    }
+}
+
+/// Returns Ok(()) if the given value is a string or a numeric
+pub fn expect_number_or_string(actual: &Value) -> EvalexprResult<()> {
+    match actual {
+        Value::String(_) | Value::Float(_) | Value::Int(_) => Ok(()),
+        _ => Err(EvalexprError::expected_number_or_string(actual.clone())),
     }
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -167,6 +167,14 @@ pub enum EvalexprError {
         divisor: Value,
     },
 
+    /// This regular expression could not be parsed
+    InvalidRegex {
+        /// The invalid regular expression
+        regex: String,
+        /// Failure message from the regex engine
+        message: String,
+    },
+
     /// A modification was attempted on a `Context` that does not allow modifications.
     ContextNotManipulable,
 
@@ -278,6 +286,11 @@ impl EvalexprError {
 
     pub(crate) fn modulation_error(dividend: Value, divisor: Value) -> Self {
         EvalexprError::ModulationError { dividend, divisor }
+    }
+
+    /// Constructs `EvalexprError::InvalidRegex(regex)`
+    pub fn invalid_regex(regex: String, message: String) -> Self {
+        EvalexprError::InvalidRegex{ regex, message }
     }
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -167,7 +167,7 @@ pub enum EvalexprError {
         divisor: Value,
     },
 
-    /// This regular expression could not be parsed
+    /// A regular expression could not be parsed
     InvalidRegex {
         /// The invalid regular expression
         regex: String,

--- a/src/function/builtin.rs
+++ b/src/function/builtin.rs
@@ -1,7 +1,26 @@
+#[cfg(feature = "regex_support")]
+use regex::Regex;
+
+use crate::error::*;
 use value::{FloatType, IntType};
 use EvalexprError;
 use Function;
 use Value;
+
+#[cfg(feature = "regex_support")]
+fn regex_with_local_errors(re_str: &str) -> Result<Regex, EvalexprError> {
+    match Regex::new(re_str) {
+        Ok(re) => Ok(re),
+        Err(regex::Error::Syntax(message)) =>
+            Err(EvalexprError::invalid_regex(re_str.to_string(), message)),
+        Err(regex::Error::CompiledTooBig(max_size)) =>
+            Err(EvalexprError::invalid_regex(
+                re_str.to_string(),
+                format!("Regex exceeded max size {}", max_size))
+            ),
+        Err(err) => Err(EvalexprError::CustomMessage(err.to_string())),
+    }
+}
 
 pub fn builtin_function(identifier: &str) -> Option<Function> {
     match identifier {
@@ -51,6 +70,62 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
                 } else {
                     Ok(Value::Float(max_float))
                 }
+            }),
+        )),
+
+        // string functions
+
+        "downcase" => Some(Function::new(
+            Some(1),
+            Box::new(|arguments| {
+                let subject = expect_string(&arguments[0])?;
+                Ok(Value::from(subject.to_lowercase()))
+            }),
+        )),
+        "len" => Some(Function::new(
+            Some(1),
+            Box::new(|arguments| {
+                let subject = expect_string(&arguments[0])?;
+                Ok(Value::from(subject.len() as i64))
+            }),
+        )),
+        #[cfg(feature = "regex_support")]
+        "match" => Some(Function::new(
+            Some(2),
+            Box::new(|arguments| {
+                let subject = expect_string(&arguments[0])?;
+                let re_str = expect_string(&arguments[1])?;
+                match regex_with_local_errors(re_str) {
+                    Ok(re) => Ok(Value::Boolean(re.is_match(subject))),
+                    Err(err) => Err(err)
+                }
+            }),
+        )),
+        #[cfg(feature = "regex_support")]
+        "replace" => Some(Function::new(
+            Some(3),
+            Box::new(|arguments| {
+                let subject = expect_string(&arguments[0])?;
+                let re_str = expect_string(&arguments[1])?;
+                let repl = expect_string(&arguments[2])?;
+                match regex_with_local_errors(re_str) {
+                    Ok(re) => Ok(Value::String(re.replace_all(subject, repl).to_string())),
+                    Err(err) => Err(err),
+                }
+            }),
+        )),
+        "trim" => Some(Function::new(
+            Some(1),
+            Box::new(|arguments| {
+                let subject = expect_string(&arguments[0])?;
+                Ok(Value::from(subject.trim()))
+            }),
+        )),
+        "upcase" => Some(Function::new(
+            Some(1),
+            Box::new(|arguments| {
+                let subject = expect_string(&arguments[0])?;
+                Ok(Value::from(subject.to_uppercase()))
             }),
         )),
         _ => None,

--- a/src/function/builtin.rs
+++ b/src/function/builtin.rs
@@ -58,15 +58,6 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
             }),
         )),
 
-        // string functions
-
-        "to_lowercase" => Some(Function::new(
-            Some(1),
-            Box::new(|arguments| {
-                let subject = expect_string(&arguments[0])?;
-                Ok(Value::from(subject.to_lowercase()))
-            }),
-        )),
         "len" => Some(Function::new(
             Some(1),
             Box::new(|arguments| {
@@ -74,8 +65,11 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
                 Ok(Value::from(subject.len() as i64))
             }),
         )),
+
+        // string functions
+
         #[cfg(feature = "regex_support")]
-        "regex_matches" => Some(Function::new(
+        "str::regex_matches" => Some(Function::new(
             Some(2),
             Box::new(|arguments| {
                 let subject = expect_string(&arguments[0])?;
@@ -87,7 +81,7 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
             }),
         )),
         #[cfg(feature = "regex_support")]
-        "regex_replace" => Some(Function::new(
+        "str::regex_replace" => Some(Function::new(
             Some(3),
             Box::new(|arguments| {
                 let subject = expect_string(&arguments[0])?;
@@ -99,18 +93,25 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
                 }
             }),
         )),
-        "trim" => Some(Function::new(
+        "str::to_lowercase" => Some(Function::new(
             Some(1),
             Box::new(|arguments| {
                 let subject = expect_string(&arguments[0])?;
-                Ok(Value::from(subject.trim()))
+                Ok(Value::from(subject.to_lowercase()))
             }),
         )),
-        "to_uppercase" => Some(Function::new(
+        "str::to_uppercase" => Some(Function::new(
             Some(1),
             Box::new(|arguments| {
                 let subject = expect_string(&arguments[0])?;
                 Ok(Value::from(subject.to_uppercase()))
+            }),
+        )),
+        "str::trim" => Some(Function::new(
+            Some(1),
+            Box::new(|arguments| {
+                let subject = expect_string(&arguments[0])?;
+                Ok(Value::from(subject.trim()))
             }),
         )),
         _ => None,

--- a/src/function/builtin.rs
+++ b/src/function/builtin.rs
@@ -60,7 +60,7 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
 
         // string functions
 
-        "downcase" => Some(Function::new(
+        "to_lowercase" => Some(Function::new(
             Some(1),
             Box::new(|arguments| {
                 let subject = expect_string(&arguments[0])?;
@@ -106,7 +106,7 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
                 Ok(Value::from(subject.trim()))
             }),
         )),
-        "upcase" => Some(Function::new(
+        "to_uppercase" => Some(Function::new(
             Some(1),
             Box::new(|arguments| {
                 let subject = expect_string(&arguments[0])?;

--- a/src/function/builtin.rs
+++ b/src/function/builtin.rs
@@ -7,21 +7,6 @@ use EvalexprError;
 use Function;
 use Value;
 
-#[cfg(feature = "regex_support")]
-fn regex_with_local_errors(re_str: &str) -> Result<Regex, EvalexprError> {
-    match Regex::new(re_str) {
-        Ok(re) => Ok(re),
-        Err(regex::Error::Syntax(message)) =>
-            Err(EvalexprError::invalid_regex(re_str.to_string(), message)),
-        Err(regex::Error::CompiledTooBig(max_size)) =>
-            Err(EvalexprError::invalid_regex(
-                re_str.to_string(),
-                format!("Regex exceeded max size {}", max_size))
-            ),
-        Err(err) => Err(EvalexprError::CustomMessage(err.to_string())),
-    }
-}
-
 pub fn builtin_function(identifier: &str) -> Option<Function> {
     match identifier {
         "min" => Some(Function::new(
@@ -90,27 +75,27 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
             }),
         )),
         #[cfg(feature = "regex_support")]
-        "match" => Some(Function::new(
+        "regex_matches" => Some(Function::new(
             Some(2),
             Box::new(|arguments| {
                 let subject = expect_string(&arguments[0])?;
                 let re_str = expect_string(&arguments[1])?;
-                match regex_with_local_errors(re_str) {
+                match Regex::new(re_str) {
                     Ok(re) => Ok(Value::Boolean(re.is_match(subject))),
-                    Err(err) => Err(err)
+                    Err(err) => Err(EvalexprError::invalid_regex(re_str.to_string(), format!("{}", err)))
                 }
             }),
         )),
         #[cfg(feature = "regex_support")]
-        "replace" => Some(Function::new(
+        "regex_replace" => Some(Function::new(
             Some(3),
             Box::new(|arguments| {
                 let subject = expect_string(&arguments[0])?;
                 let re_str = expect_string(&arguments[1])?;
                 let repl = expect_string(&arguments[2])?;
-                match regex_with_local_errors(re_str) {
+                match Regex::new(re_str) {
                     Ok(re) => Ok(Value::String(re.replace_all(subject, repl).to_string())),
-                    Err(err) => Err(err),
+                    Err(err) => Err(EvalexprError::invalid_regex(re_str.to_string(), format!("{}", err))),
                 }
             }),
         )),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,6 +347,8 @@
 
 #![warn(missing_docs)]
 
+#[cfg(feature = "regex_support")]
+extern crate regex;
 #[cfg(test)]
 extern crate ron;
 #[cfg(feature = "serde_support")]

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -146,10 +146,15 @@ impl Operator for Add {
 
     fn eval(&self, arguments: &[Value], _context: &Context) -> EvalexprResult<Value> {
         expect_operator_argument_amount(arguments.len(), 2)?;
-        expect_number(&arguments[0])?;
-        expect_number(&arguments[1])?;
+        expect_number_or_string(&arguments[0])?;
+        expect_number_or_string(&arguments[1])?;
 
-        if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
+        if let (Ok(a), Ok(b)) = (arguments[0].as_string(), arguments[1].as_string()) {
+            let mut result = String::with_capacity(a.len() + b.len());
+            result.push_str(&a);
+            result.push_str(&b);
+            Ok(Value::String(result))
+        } else if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
             let result = a.checked_add(b);
             if let Some(result) = result {
                 Ok(Value::Int(result))
@@ -395,10 +400,16 @@ impl Operator for Gt {
 
     fn eval(&self, arguments: &[Value], _context: &Context) -> EvalexprResult<Value> {
         expect_operator_argument_amount(arguments.len(), 2)?;
-        expect_number(&arguments[0])?;
-        expect_number(&arguments[1])?;
+        expect_number_or_string(&arguments[0])?;
+        expect_number_or_string(&arguments[1])?;
 
-        if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
+        if let (Ok(a), Ok(b)) = (arguments[0].as_string(), arguments[1].as_string()) {
+            if a > b {
+                Ok(Value::Boolean(true))
+            } else {
+                Ok(Value::Boolean(false))
+            }
+        } else if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
             if a > b {
                 Ok(Value::Boolean(true))
             } else {
@@ -425,10 +436,16 @@ impl Operator for Lt {
 
     fn eval(&self, arguments: &[Value], _context: &Context) -> EvalexprResult<Value> {
         expect_operator_argument_amount(arguments.len(), 2)?;
-        expect_number(&arguments[0])?;
-        expect_number(&arguments[1])?;
+        expect_number_or_string(&arguments[0])?;
+        expect_number_or_string(&arguments[1])?;
 
-        if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
+        if let (Ok(a), Ok(b)) = (arguments[0].as_string(), arguments[1].as_string()) {
+            if a < b {
+                Ok(Value::Boolean(true))
+            } else {
+                Ok(Value::Boolean(false))
+            }
+        } else if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
             if a < b {
                 Ok(Value::Boolean(true))
             } else {
@@ -455,10 +472,16 @@ impl Operator for Geq {
 
     fn eval(&self, arguments: &[Value], _context: &Context) -> EvalexprResult<Value> {
         expect_operator_argument_amount(arguments.len(), 2)?;
-        expect_number(&arguments[0])?;
-        expect_number(&arguments[1])?;
+        expect_number_or_string(&arguments[0])?;
+        expect_number_or_string(&arguments[1])?;
 
-        if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
+        if let (Ok(a), Ok(b)) = (arguments[0].as_string(), arguments[1].as_string()) {
+            if a >= b {
+                Ok(Value::Boolean(true))
+            } else {
+                Ok(Value::Boolean(false))
+            }
+        } else if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
             if a >= b {
                 Ok(Value::Boolean(true))
             } else {
@@ -485,10 +508,16 @@ impl Operator for Leq {
 
     fn eval(&self, arguments: &[Value], _context: &Context) -> EvalexprResult<Value> {
         expect_operator_argument_amount(arguments.len(), 2)?;
-        expect_number(&arguments[0])?;
-        expect_number(&arguments[1])?;
+        expect_number_or_string(&arguments[0])?;
+        expect_number_or_string(&arguments[1])?;
 
-        if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
+        if let (Ok(a), Ok(b)) = (arguments[0].as_string(), arguments[1].as_string()) {
+            if a <= b {
+                Ok(Value::Boolean(true))
+            } else {
+                Ok(Value::Boolean(false))
+            }
+        } else if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
             if a <= b {
                 Ok(Value::Boolean(true))
             } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -288,7 +288,7 @@ fn test_builtin_functions() {
         Ok(Value::Float(4.0))
     );
     assert_eq!(
-        eval("downcase(\"FOOBAR\")"),
+        eval("to_lowercase(\"FOOBAR\")"),
         Ok(Value::from("foobar"))
     );
     assert_eq!(
@@ -300,7 +300,7 @@ fn test_builtin_functions() {
         Ok(Value::from("foo  bar"))
     );
     assert_eq!(
-        eval("upcase(\"foobar\")"),
+        eval("to_uppercase(\"foobar\")"),
         Ok(Value::from("FOOBAR"))
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -309,14 +309,14 @@ fn test_builtin_functions() {
 #[cfg(feature = "regex_support")]
 fn test_regex_functions() {
     assert_eq!(
-        eval("match(\"foobar\", \"[ob]{3}\")"),
+        eval("regex_matches(\"foobar\", \"[ob]{3}\")"),
         Ok(Value::Boolean(true))
     );
     assert_eq!(
-        eval("match(\"gazonk\", \"[ob]{3}\")"),
+        eval("regex_matches(\"gazonk\", \"[ob]{3}\")"),
         Ok(Value::Boolean(false))
     );
-    match eval("match(\"foo\", \"[\")") {
+    match eval("regex_matches(\"foo\", \"[\")") {
         Err(EvalexprError::InvalidRegex{ regex, message }) => {
             assert_eq!(regex, "[");
             assert!(message.contains("unclosed character class"));
@@ -324,11 +324,11 @@ fn test_regex_functions() {
         v => panic!(v),
     };
     assert_eq!(
-        eval("replace(\"foobar\", \".*?(o+)\", \"b$1\")"),
+        eval("regex_replace(\"foobar\", \".*?(o+)\", \"b$1\")"),
         Ok(Value::String("boobar".to_owned()))
     );
     assert_eq!(
-        eval("replace(\"foobar\", \".*?(i+)\", \"b$1\")"),
+        eval("regex_replace(\"foobar\", \".*?(i+)\", \"b$1\")"),
         Ok(Value::String("foobar".to_owned()))
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -288,20 +288,20 @@ fn test_builtin_functions() {
         Ok(Value::Float(4.0))
     );
     assert_eq!(
-        eval("to_lowercase(\"FOOBAR\")"),
-        Ok(Value::from("foobar"))
-    );
-    assert_eq!(
         eval("len(\"foobar\")"),
         Ok(Value::Int(6))
     );
     assert_eq!(
-        eval("trim(\"  foo  bar \")"),
-        Ok(Value::from("foo  bar"))
+        eval("str::to_lowercase(\"FOOBAR\")"),
+        Ok(Value::from("foobar"))
     );
     assert_eq!(
-        eval("to_uppercase(\"foobar\")"),
+        eval("str::to_uppercase(\"foobar\")"),
         Ok(Value::from("FOOBAR"))
+    );
+    assert_eq!(
+        eval("str::trim(\"  foo  bar \")"),
+        Ok(Value::from("foo  bar"))
     );
 }
 
@@ -309,14 +309,14 @@ fn test_builtin_functions() {
 #[cfg(feature = "regex_support")]
 fn test_regex_functions() {
     assert_eq!(
-        eval("regex_matches(\"foobar\", \"[ob]{3}\")"),
+        eval("str::regex_matches(\"foobar\", \"[ob]{3}\")"),
         Ok(Value::Boolean(true))
     );
     assert_eq!(
-        eval("regex_matches(\"gazonk\", \"[ob]{3}\")"),
+        eval("str::regex_matches(\"gazonk\", \"[ob]{3}\")"),
         Ok(Value::Boolean(false))
     );
-    match eval("regex_matches(\"foo\", \"[\")") {
+    match eval("str::regex_matches(\"foo\", \"[\")") {
         Err(EvalexprError::InvalidRegex{ regex, message }) => {
             assert_eq!(regex, "[");
             assert!(message.contains("unclosed character class"));
@@ -324,11 +324,11 @@ fn test_regex_functions() {
         v => panic!(v),
     };
     assert_eq!(
-        eval("regex_replace(\"foobar\", \".*?(o+)\", \"b$1\")"),
+        eval("str::regex_replace(\"foobar\", \".*?(o+)\", \"b$1\")"),
         Ok(Value::String("boobar".to_owned()))
     );
     assert_eq!(
-        eval("regex_replace(\"foobar\", \".*?(i+)\", \"b$1\")"),
+        eval("str::regex_replace(\"foobar\", \".*?(i+)\", \"b$1\")"),
         Ok(Value::String("foobar".to_owned()))
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -551,6 +551,9 @@ fn test_strings() {
         eval_boolean_with_context("a == \"a string\"", &context),
         Ok(true)
     );
+    assert_eq!(eval("\"a\" + \"b\""), Ok(Value::from("ab")));
+    assert_eq!(eval("\"a\" > \"b\""), Ok(Value::from(false)));
+    assert_eq!(eval("\"a\" < \"b\""), Ok(Value::from(true)));
 }
 
 #[cfg(feature = "serde")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -275,14 +275,61 @@ fn test_n_ary_functions() {
         Ok(Value::Int(3))
     );
     assert_eq!(eval_with_context("count 5", &context), Ok(Value::Int(1)));
+}
 
+#[test]
+fn test_builtin_functions() {
     assert_eq!(
-        eval_with_context("min(4.0, 3)", &context),
+        eval("min(4.0, 3)"),
         Ok(Value::Int(3))
     );
     assert_eq!(
-        eval_with_context("max(4.0, 3)", &context),
+        eval("max(4.0, 3)"),
         Ok(Value::Float(4.0))
+    );
+    assert_eq!(
+        eval("downcase(\"FOOBAR\")"),
+        Ok(Value::from("foobar"))
+    );
+    assert_eq!(
+        eval("len(\"foobar\")"),
+        Ok(Value::Int(6))
+    );
+    assert_eq!(
+        eval("trim(\"  foo  bar \")"),
+        Ok(Value::from("foo  bar"))
+    );
+    assert_eq!(
+        eval("upcase(\"foobar\")"),
+        Ok(Value::from("FOOBAR"))
+    );
+}
+
+#[test]
+#[cfg(feature = "regex_support")]
+fn test_regex_functions() {
+    assert_eq!(
+        eval("match(\"foobar\", \"[ob]{3}\")"),
+        Ok(Value::Boolean(true))
+    );
+    assert_eq!(
+        eval("match(\"gazonk\", \"[ob]{3}\")"),
+        Ok(Value::Boolean(false))
+    );
+    match eval("match(\"foo\", \"[\")") {
+        Err(EvalexprError::InvalidRegex{ regex, message }) => {
+            assert_eq!(regex, "[");
+            assert!(message.contains("unclosed character class"));
+        },
+        v => panic!(v),
+    };
+    assert_eq!(
+        eval("replace(\"foobar\", \".*?(o+)\", \"b$1\")"),
+        Ok(Value::String("boobar".to_owned()))
+    );
+    assert_eq!(
+        eval("replace(\"foobar\", \".*?(i+)\", \"b$1\")"),
+        Ok(Value::String("foobar".to_owned()))
     );
 }
 


### PR DESCRIPTION
I'm planning a project which will have both rules (i.e. boolean expressions) and transformations (i.e. string expressions) in the same configuration entry, so it makes sense to use a library with support for both to get a unified syntax for these expressions. Evalexpr almost fills this description, but would need a bit more string support. Given that these functions are pretty standard, I thought it makes sense to contribute them upstream rather than keep them locally.

This PR introduces common operations for strings:

| Identifier | Argument Amount | Description |
|------------|-----------------|-------------|
| downcase | 1 | Returns lower-case version of string |
| len | 1 | Return the character length of string argument |
| match | 2 | Returns true if first string argument matches regex in second |
| replace | 3 | Returns string with matches replaced by third argument |
| trim | 1 | Strips whitespace from start and end of string |
| upcase | 1 | Returns upper-case version of string |

This PR adds a dependence on the `regex` crate. This should probably be optional, but I'm thinking it is so likely that a string user will want to use regexes that it might make more sense to try to make all string functions optional?