### PR TITLE
Use the new context macro in the README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,28 +65,28 @@ use evalexpr::*;
 use evalexpr::error::expect_number;
 
 let context = context_map! {
-  "five" => 5,
-  "twelve" => 12,
-  "f" => Function::new(Some(1) /* argument amount */, Box::new(|arguments| {
-      if let Value::Int(int) = arguments[0] {
-          Ok(Value::Int(int / 2))
-      } else if let Value::Float(float) = arguments[0] {
-          Ok(Value::Float(float / 2.0))
-      } else {
-          Err(EvalexprError::expected_number(arguments[0].clone()))
-      }
-  })),
-  "avg" => Function::new(Some(2) /* argument amount */, Box::new(|arguments| {
-      expect_number(&arguments[0])?;
-      expect_number(&arguments[1])?;
+    "five" => 5,
+    "twelve" => 12,
+    "f" => Function::new(Some(1) /* argument amount */, Box::new(|arguments| {
+        if let Value::Int(int) = arguments[0] {
+            Ok(Value::Int(int / 2))
+        } else if let Value::Float(float) = arguments[0] {
+            Ok(Value::Float(float / 2.0))
+        } else {
+            Err(EvalexprError::expected_number(arguments[0].clone()))
+        }
+    })),
+    "avg" => Function::new(Some(2) /* argument amount */, Box::new(|arguments| {
+        expect_number(&arguments[0])?;
+        expect_number(&arguments[1])?;
 
-      if let (Value::Int(a), Value::Int(b)) = (&arguments[0], &arguments[1]) {
-          Ok(Value::Int((a + b) / 2))
-      } else {
-          Ok(Value::Float((arguments[0].as_number()? + arguments[1].as_number()?) / 2.0))
-      }
-  }))
- }.unwrap();
+        if let (Value::Int(a), Value::Int(b)) = (&arguments[0], &arguments[1]) {
+            Ok(Value::Int((a + b) / 2))
+        } else {
+            Ok(Value::Float((arguments[0].as_number()? + arguments[1].as_number()?) / 2.0))
+        }
+    }))
+}.unwrap(); // Do proper error handling here
 
 assert_eq!(eval_with_context("five + 8 > f(twelve)", &context), Ok(Value::from(true)));
 // `eval_with_context` returns a variant of the `Value` enum,
@@ -104,10 +104,10 @@ use evalexpr::*;
 let precompiled = build_operator_tree("a * b - c > 5").unwrap(); // Do proper error handling here
 
 let mut context = context_map! {
-  "a" => 6,
-  "b" => 2,
-  "c" => 3
-}.unwrap();
+    "a" => 6,
+    "b" => 2,
+    "c" => 3
+}.unwrap(); // Do proper error handling here
 assert_eq!(precompiled.eval_with_context(&context), Ok(Value::from(true)));
 
 context.set_value("c".into(), 8.into()).unwrap(); // Do proper error handling here
@@ -345,8 +345,9 @@ Example parsing with [ron format](docs.rs/ron):
 extern crate ron;
 use evalexpr::*;
 
-let mut context = HashMapContext::new();
-context.set_value("five".into(), 5.into()).unwrap(); // Do proper error handling here
+let mut context = context_map!{
+    "five" => 5
+}.unwrap(); // Do proper error handling here
 
 // In ron format, strings are surrounded by "
 let serialized_free = "\"five * five\"";

--- a/README.md
+++ b/README.md
@@ -64,28 +64,29 @@ And you can use **variables** and **functions** in expressions like this:
 use evalexpr::*;
 use evalexpr::error::expect_number;
 
-let mut context = HashMapContext::new();
-context.set_value("five".into(), 5.into()).unwrap(); // Do proper error handling here
-context.set_value("twelve".into(), 12.into()).unwrap(); // Do proper error handling here
-context.set_function("f".into(), Function::new(Some(1) /* argument amount */, Box::new(|arguments| {
-    if let Value::Int(int) = arguments[0] {
-        Ok(Value::Int(int / 2))
-    } else if let Value::Float(float) = arguments[0] {
-        Ok(Value::Float(float / 2.0))
-    } else {
-        Err(EvalexprError::expected_number(arguments[0].clone()))
-    }
-}))).unwrap(); // Do proper error handling here
-context.set_function("avg".into(), Function::new(Some(2) /* argument amount */, Box::new(|arguments| {
-    expect_number(&arguments[0])?;
-    expect_number(&arguments[1])?;
+let context = context_map! {
+  "five" => 5,
+  "twelve" => 12,
+  "f" => Function::new(Some(1) /* argument amount */, Box::new(|arguments| {
+      if let Value::Int(int) = arguments[0] {
+          Ok(Value::Int(int / 2))
+      } else if let Value::Float(float) = arguments[0] {
+          Ok(Value::Float(float / 2.0))
+      } else {
+          Err(EvalexprError::expected_number(arguments[0].clone()))
+      }
+  })),
+  "avg" => Function::new(Some(2) /* argument amount */, Box::new(|arguments| {
+      expect_number(&arguments[0])?;
+      expect_number(&arguments[1])?;
 
-    if let (Value::Int(a), Value::Int(b)) = (&arguments[0], &arguments[1]) {
-        Ok(Value::Int((a + b) / 2))
-    } else {
-        Ok(Value::Float((arguments[0].as_number()? + arguments[1].as_number()?) / 2.0))
-    }
-}))).unwrap(); // Do proper error handling here
+      if let (Value::Int(a), Value::Int(b)) = (&arguments[0], &arguments[1]) {
+          Ok(Value::Int((a + b) / 2))
+      } else {
+          Ok(Value::Float((arguments[0].as_number()? + arguments[1].as_number()?) / 2.0))
+      }
+  }))
+ }.unwrap();
 
 assert_eq!(eval_with_context("five + 8 > f(twelve)", &context), Ok(Value::from(true)));
 // `eval_with_context` returns a variant of the `Value` enum,
@@ -102,10 +103,11 @@ use evalexpr::*;
 
 let precompiled = build_operator_tree("a * b - c > 5").unwrap(); // Do proper error handling here
 
-let mut context = HashMapContext::new();
-context.set_value("a".into(), 6.into()).unwrap(); // Do proper error handling here
-context.set_value("b".into(), 2.into()).unwrap(); // Do proper error handling here
-context.set_value("c".into(), 3.into()).unwrap(); // Do proper error handling here
+let mut context = context_map! {
+  "a" => 6,
+  "b" => 2,
+  "c" => 3
+}.unwrap();
 assert_eq!(precompiled.eval_with_context(&context), Ok(Value::from(true)));
 
 context.set_value("c".into(), 8.into()).unwrap(); // Do proper error handling here

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,28 +51,29 @@
 //! use evalexpr::*;
 //! use evalexpr::error::expect_number;
 //!
-//! let mut context = HashMapContext::new();
-//! context.set_value("five".into(), 5.into()).unwrap(); // Do proper error handling here
-//! context.set_value("twelve".into(), 12.into()).unwrap(); // Do proper error handling here
-//! context.set_function("f".into(), Function::new(Some(1) /* argument amount */, Box::new(|arguments| {
-//!     if let Value::Int(int) = arguments[0] {
-//!         Ok(Value::Int(int / 2))
-//!     } else if let Value::Float(float) = arguments[0] {
-//!         Ok(Value::Float(float / 2.0))
-//!     } else {
-//!         Err(EvalexprError::expected_number(arguments[0].clone()))
-//!     }
-//! }))).unwrap(); // Do proper error handling here
-//! context.set_function("avg".into(), Function::new(Some(2) /* argument amount */, Box::new(|arguments| {
-//!     expect_number(&arguments[0])?;
-//!     expect_number(&arguments[1])?;
+//! let context = context_map! {
+//!     "five" => 5,
+//!     "twelve" => 12,
+//!     "f" => Function::new(Some(1) /* argument amount */, Box::new(|arguments| {
+//!         if let Value::Int(int) = arguments[0] {
+//!             Ok(Value::Int(int / 2))
+//!         } else if let Value::Float(float) = arguments[0] {
+//!             Ok(Value::Float(float / 2.0))
+//!         } else {
+//!             Err(EvalexprError::expected_number(arguments[0].clone()))
+//!         }
+//!     })),
+//!     "avg" => Function::new(Some(2) /* argument amount */, Box::new(|arguments| {
+//!         expect_number(&arguments[0])?;
+//!         expect_number(&arguments[1])?;
 //!
-//!     if let (Value::Int(a), Value::Int(b)) = (&arguments[0], &arguments[1]) {
-//!         Ok(Value::Int((a + b) / 2))
-//!     } else {
-//!         Ok(Value::Float((arguments[0].as_number()? + arguments[1].as_number()?) / 2.0))
-//!     }
-//! }))).unwrap(); // Do proper error handling here
+//!         if let (Value::Int(a), Value::Int(b)) = (&arguments[0], &arguments[1]) {
+//!             Ok(Value::Int((a + b) / 2))
+//!         } else {
+//!             Ok(Value::Float((arguments[0].as_number()? + arguments[1].as_number()?) / 2.0))
+//!         }
+//!     }))
+//! }.unwrap(); // Do proper error handling here
 //!
 //! assert_eq!(eval_with_context("five + 8 > f(twelve)", &context), Ok(Value::from(true)));
 //! // `eval_with_context` returns a variant of the `Value` enum,
@@ -89,10 +90,11 @@
 //!
 //! let precompiled = build_operator_tree("a * b - c > 5").unwrap(); // Do proper error handling here
 //!
-//! let mut context = HashMapContext::new();
-//! context.set_value("a".into(), 6.into()).unwrap(); // Do proper error handling here
-//! context.set_value("b".into(), 2.into()).unwrap(); // Do proper error handling here
-//! context.set_value("c".into(), 3.into()).unwrap(); // Do proper error handling here
+//! let mut context = context_map! {
+//!     "a" => 6,
+//!     "b" => 2,
+//!     "c" => 3
+//! }.unwrap(); // Do proper error handling here
 //! assert_eq!(precompiled.eval_with_context(&context), Ok(Value::from(true)));
 //!
 //! context.set_value("c".into(), 8.into()).unwrap(); // Do proper error handling here
@@ -330,8 +332,9 @@
 //! extern crate ron;
 //! use evalexpr::*;
 //!
-//! let mut context = HashMapContext::new();
-//! context.set_value("five".into(), 5.into()).unwrap(); // Do proper error handling here
+//! let mut context = context_map!{
+//!     "five" => 5
+//! }.unwrap(); // Do proper error handling here
 //!
 //! // In ron format, strings are surrounded by "
 //! let serialized_free = "\"five * five\"";


### PR DESCRIPTION
This makes the README more digest, in my opinion.