### PR TITLE
Implement Clone for HashMapContext

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -70,7 +70,7 @@ impl Context for EmptyContext {
 /// *Value and function mappings are stored independently, meaning that there can be a function and a value with the same identifier.*
 ///
 /// This context is type-safe, meaning that an identifier that is assigned a value of some type once cannot be assigned a value of another type.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct HashMapContext {
     variables: HashMap<String, Value>,


### PR DESCRIPTION
This makes it easier to reuse a context, without having to recreate it from scratch.