### PR TITLE
Add support for scientific notation of the form `<coefficient>e{+,-,}<exponent>`

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,6 +17,11 @@ fn test_unary_examples() {
     assert_eq!(eval("-3"), Ok(Value::Int(-3)));
     assert_eq!(eval("-3.6"), Ok(Value::Float(-3.6)));
     assert_eq!(eval("----3"), Ok(Value::Int(3)));
+    assert_eq!(eval("1e0"), Ok(Value::Float(1.0)));
+    assert_eq!(eval("1e-0"), Ok(Value::Float(1.0)));
+    assert_eq!(eval("10e3"), Ok(Value::Float(10000.0)));
+    assert_eq!(eval("10e+3"), Ok(Value::Float(10000.0)));
+    assert_eq!(eval("10e-3"), Ok(Value::Float(0.01)));
 }
 
 #[test]
@@ -41,6 +46,8 @@ fn test_binary_examples() {
     assert_eq!(eval("3+-1"), Ok(Value::Int(2)));
     assert_eq!(eval("-3-5"), Ok(Value::Int(-8)));
     assert_eq!(eval("-5--3"), Ok(Value::Int(-2)));
+    assert_eq!(eval("5e2--3"), Ok(Value::Float(503.0)));
+    assert_eq!(eval("-5e-2--3"), Ok(Value::Float(2.95)));
 }
 
 #[test]


### PR DESCRIPTION
Rust's number parsing supports parsing floats in the [scientific notation](https://en.wikipedia.org/wiki/Scientific_notation) format ([playground example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=b81e8ef24628965bb50c10a15ae4287c)). This is useful for dealing with values of electronic components (resistance, capacitance), that are often very small/large.

Right now `evalexpr` correctly recognizes input of the form `10e3` as it's parsed as a single `PartialToken::Literal`. However, adding a `+` or `-` for negative values i.e. `10e-3` will cause `str_to_partial_tokens` to output `[Literal("10e"), Minus, Literal("3")]` due to the parsing logic not handling `e` in any special way. This causes `evalexpr` to not find a variable with the identifier `10e` and fail. The proposed fix for this issue doesn't alter the partial token logic, but instead adds some extra handling when resolving partial tokens to full tokens. This is the smallest change I could come up with to implement this, let me know if it would be better to do it another way (the current architecture doesn't adapt to supporting this very easily). I've also added some additional cases to the integration tests to cover the scientific notation parsing.