### PR TITLE
Implement bitwise shift functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ This crate offers a set of builtin functions.
 | `bitor`              | 2               | Int                    | Computes the bitwise or of the given integers |
 | `bitxor`             | 2               | Int                    | Computes the bitwise xor of the given integers |
 | `bitnot`             | 1               | Int                    | Computes the bitwise not of the given integer |
+| `shl`                | 2               | Int                    | Computes the given integer bitwise shifted left by the other given integer |
+| `shr`                | 2               | Int                    | Computes the given integer bitwise shifted right by the other given integer |
 
 The `min` and `max` functions can deal with a mixture of integer and floating point arguments.
 If the maximum or minimum is an integer, then an integer is returned.

--- a/src/function/builtin.rs
+++ b/src/function/builtin.rs
@@ -5,7 +5,7 @@ use crate::{
     value::{FloatType, IntType},
     EvalexprError, Function, Value, ValueType,
 };
-use std::ops::{BitAnd, BitOr, BitXor, Not};
+use std::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
 
 macro_rules! simple_math {
     ($func:ident) => {
@@ -185,6 +185,8 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
         "bitor" => int_function!(bitor, 2),
         "bitxor" => int_function!(bitxor, 2),
         "bitnot" => int_function!(not),
+        "shl" => int_function!(shl, 2),
+        "shr" => int_function!(shr, 2),
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,8 @@
 //! | `bitor`              | 2               | Int                    | Computes the bitwise or of the given integers |
 //! | `bitxor`             | 2               | Int                    | Computes the bitwise xor of the given integers |
 //! | `bitnot`             | 1               | Int                    | Computes the bitwise not of the given integer |
+//! | `shl`                | 2               | Int                    | Computes the given integer bitwise shifted left by the other given integer |
+//! | `shr`                | 2               | Int                    | Computes the given integer bitwise shifted right by the other given integer |
 //!
 //! The `min` and `max` functions can deal with a mixture of integer and floating point arguments.
 //! If the maximum or minimum is an integer, then an integer is returned.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -395,6 +395,7 @@ fn test_builtin_functions() {
         Ok(Value::String(String::from("(1, 2, 3)")))
     );
     assert_eq!(eval("str::from()"), Ok(Value::String(String::from("()"))));
+    // Bitwise
     assert_eq!(eval("bitand(5, -1)"), Ok(Value::Int(5)));
     assert_eq!(eval("bitand(6, 5)"), Ok(Value::Int(4)));
     assert_eq!(eval("bitor(5, -1)"), Ok(Value::Int(-1)));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -403,6 +403,10 @@ fn test_builtin_functions() {
     assert_eq!(eval("bitxor(6, 5)"), Ok(Value::Int(3)));
     assert_eq!(eval("bitnot(5)"), Ok(Value::Int(-6)));
     assert_eq!(eval("bitnot(-1)"), Ok(Value::Int(0)));
+    assert_eq!(eval("shl(5, 1)"), Ok(Value::Int(10)));
+    assert_eq!(eval("shl(-6, 5)"), Ok(Value::Int(-192)));
+    assert_eq!(eval("shr(5, 1)"), Ok(Value::Int(2)));
+    assert_eq!(eval("shr(-6, 5)"), Ok(Value::Int(-1)));
 }
 
 #[test]


### PR DESCRIPTION
Adds the `shl` and `shr` builtin functions for bitwise left and right shifts.

I decided to use this crate for an assembler I'm working on, but I need support for the shift operators, which this was missing. So I went ahead and added them!