### PR TITLE
Add support for is_nan and other floating-point functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
               command: clippy
               args: --all-features --tests --benches
               components: clippy
+          - toolchain: stable
+            command:
+              name: Sync readme
+              command: sync-readme
+              args: --check
+              components: cargo-sync-readme
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
               name: Sync readme
               command: sync-readme
               args: --check
-              components: cargo-sync-readme
 
     steps:
       - uses: actions/checkout@v2
@@ -58,6 +57,12 @@ jobs:
           override: true
           default: true
           components: ${{matrix.command.components}}
+
+      - name: Install cargo-sync-readme
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-sync-readme
 
       - name: ${{matrix.command.name}}
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,19 @@
 
 ### Contributors
 
-## [7.1.1](https://github.com/ISibboI/evalexpr/compare/7.1.1...7.1.1) - 2022-03-14
+## [7.2.0](https://github.com/ISibboI/evalexpr/compare/7.1.1...7.2.0) - 2022-03-16
+
+### Added
+
+ * The builtin function `if`, which mimics the if-else construct existing in many programming languages.
+
+### Contributors
+
+My warmhearted thanks goes to:
+
+ * [Ophir LOJKINE](https://github.com/lovasoa)
+
+## [7.1.1](https://github.com/ISibboI/evalexpr/compare/7.1.0...7.1.1) - 2022-03-14
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evalexpr"
-version = "7.1.1"
+version = "7.2.0"
 description = "A powerful arithmetic and boolean expression evaluator"
 keywords = ["expression", "evaluate", "evaluator", "arithmetic", "boolean"]
 categories = ["parsing", "game-engines"]

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ This crate offers a set of builtin functions.
 | `floor`              | 1               | Numeric                | Returns the largest integer less than or equal to a number |
 | `round`              | 1               | Numeric                | Returns the nearest integer to a number. Rounds half-way cases away from 0.0 |
 | `ceil`               | 1               | Numeric                | Returns the smallest integer greater than or equal to a number |
+| `if`                 | 3               | Boolean, Any, Any      | If the first argument is true, returns the second argument, otherwise, returns the third  |
 | `math::ln`           | 1               | Numeric                | Returns the natural logarithm of the number |
 | `math::log`          | 2               | Numeric, Numeric       | Returns the logarithm of the number with respect to an arbitrary base |
 | `math::log2`         | 1               | Numeric                | Returns the base 2 logarithm of the number |

--- a/src/function/builtin.rs
+++ b/src/function/builtin.rs
@@ -23,6 +23,16 @@ macro_rules! simple_math {
     };
 }
 
+fn float_is(func: fn(f64) -> bool) -> Option<Function> {
+    Some(Function::new(move |argument| {
+        if let Ok(num) = argument.as_float() {
+            Ok(func(num).into())
+        } else {
+            Ok(false.into())
+        }
+    }))
+}
+
 macro_rules! int_function {
     ($func:ident) => {
         Some(Function::new(|argument| {
@@ -76,6 +86,11 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
         "floor" => simple_math!(floor),
         "round" => simple_math!(round),
         "ceil" => simple_math!(ceil),
+        "is_nan" => float_is(f64::is_nan),
+        "is_finite" => float_is(f64::is_finite),
+        "is_infinite" => float_is(f64::is_infinite),
+        "is_normal" => float_is(f64::is_normal),
+        "is_subnormal" => float_is(f64::is_subnormal),
         // Other
         "min" => Some(Function::new(|argument| {
             let arguments = argument.as_tuple()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,11 @@
 //! | `round`              | 1               | Numeric                | Returns the nearest integer to a number. Rounds half-way cases away from 0.0 |
 //! | `ceil`               | 1               | Numeric                | Returns the smallest integer greater than or equal to a number |
 //! | `if`                 | 3               | Boolean, Any, Any      | If the first argument is true, returns the second argument, otherwise, returns the third  |
+//! | `is_nan`             | 1               | Numeric                | Returns true if the argument is the floating-point value NaN, false otherwise  |
+//! | `is_finite`          | 1               | Numeric                | Returns true if the argument is a finite floating-point number, false otherwise  |
+//! | `is_infinite`        | 1               | Numeric                | Returns true if the argument is an infinite floating-point number, false otherwise  |
+//! | `is_normal`          | 1               | Numeric                | Returns true if the argument is a floating-point number that is neither zero, infinite, subnormal, or NaN, false otherwise  |
+//! | `is_subnormal`       | 1               | Numeric                | Returns true if the argument is a [subnormal](https://en.wikipedia.org/wiki/Subnormal_number) number, false otherwise  |
 //! | `math::ln`           | 1               | Numeric                | Returns the natural logarithm of the number |
 //! | `math::log`          | 2               | Numeric, Numeric       | Returns the logarithm of the number with respect to an arbitrary base |
 //! | `math::log2`         | 1               | Numeric                | Returns the base 2 logarithm of the number |

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -362,6 +362,18 @@ fn test_builtin_functions() {
     assert_eq!(eval("round(1.9)"), Ok(Value::Float(2.0)));
     assert_eq!(eval("ceil(1.1)"), Ok(Value::Float(2.0)));
     assert_eq!(eval("ceil(1.9)"), Ok(Value::Float(2.0)));
+    assert_eq!(eval("is_nan(\"xxx\")"), Ok(Value::Boolean(false)));
+    assert_eq!(eval("is_nan(1.0/0.0)"), Ok(Value::Boolean(false)));
+    assert_eq!(eval("is_nan(0.0/0.0)"), Ok(Value::Boolean(true)));
+    assert_eq!(eval("is_finite(1.0/0.0)"), Ok(Value::Boolean(false)));
+    assert_eq!(eval("is_finite(0.0/0.0)"), Ok(Value::Boolean(false)));
+    assert_eq!(eval("is_finite(0.0)"), Ok(Value::Boolean(true)));
+    assert_eq!(eval("is_infinite(0.0/0.0)"), Ok(Value::Boolean(false)));
+    assert_eq!(eval("is_infinite(1.0/0.0)"), Ok(Value::Boolean(true)));
+    assert_eq!(eval("is_normal(1.0/0.0)"), Ok(Value::Boolean(false)));
+    assert_eq!(eval("is_normal(0)"), Ok(Value::Boolean(false)));
+    assert_eq!(eval("is_subnormal(0)"), Ok(Value::Boolean(false)));
+    assert_eq!(eval("is_subnormal(1.0e-308)"), Ok(Value::Boolean(true)));
     // Other
     assert_eq!(eval("min(4.0, 3)"), Ok(Value::Int(3)));
     assert_eq!(eval("max(4.0, 3)"), Ok(Value::Float(4.0)));


### PR DESCRIPTION
- Sync README.
- Prepare changelog for 7.2.0 release.
- Add sync-readme check to CI.
- Try fixing sync-readme in CI.
- Release 7.2.0
- Add support for is_nan, is_finite, and other floating-point testing functions
