### PR TITLE
Added Clone to errors

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -14,7 +14,7 @@ use crate::{operator::Operator, value::Value};
 mod display;
 
 /// Errors used in this crate.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum EvalexprError {
     /// An operator was called with a wrong amount of arguments.


### PR DESCRIPTION
Hi! I am writing a web service with an Error type that implements/requires clone. Since all of the sub-types of `EvalexprError ` already implement (or derive) Clone, I thought why not also add it for the Error. 

Cheers!