### PR TITLE
feature_method_to_disable_builtin_function

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ It allows using [variables](#variables), [assignments](#the-assignment-operator)
 When assigning to variables, the assignment is stored in a context.
 When the variable is read later on, it is read from the context.
 Contexts can be preserved between multiple calls to eval by creating them yourself.
+By default, Contexts have builtin functions diabled. 
+It can be disabled by calling Context::disable_builtin_fn().
 Here is a simple example to show the difference between preserving and not preserving context between evaluations:
 
 ```rust
@@ -287,6 +289,13 @@ assert_eq!(eval_with_context_mut("a = 5.5", &mut context),
            Err(EvalexprError::ExpectedInt { actual: Value::from(5.5) }));
 // Reading a variable does not require a mutable context
 assert_eq!(eval_with_context("a", &context), Ok(Value::from(5)));
+
+// Built in functions are enabled by default.
+assert_eq!(eval_with_context("max(1,3)",&context),Ok(Value::from(3)));
+// Disabling builtin function in Context.
+context.disable_builtin_fn();
+// Builting functions are disabled and using them returns Error.
+assert_eq!(eval_with_context("max(1,3)",&context),Err(EvalexprError::FunctionIdentifierNotFound(String::from("max"))));
 
 ```
 
@@ -394,6 +403,8 @@ If the maximum or minimum is an integer, then an integer is returned.
 Otherwise, a float is returned.
 
 The regex functions require the feature flag `regex_support`.
+
+The builtin functions can be disabled by calling Context::disable_builtin_fn().
 
 ### Values
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -22,6 +22,12 @@ pub trait Context {
     /// Calls the function that is linked to the given identifier with the given argument.
     /// If no function with the given identifier is found, this method returns `EvalexprError::FunctionIdentifierNotFound`.
     fn call_function(&self, identifier: &str, argument: &Value) -> EvalexprResult<Value>;
+
+    /// Checks if builtin function has been disabled.
+    fn is_builtin_fn_disabled(&self) -> bool;
+
+    /// Disables Builtin function.
+    fn disable_builtin_fn(&mut self);
 }
 
 /// A context that allows to assign to variables.
@@ -79,6 +85,12 @@ impl Context for EmptyContext {
             identifier.to_string(),
         ))
     }
+    /// Builtin functions can't be disbaled for Empty Context.
+    fn disable_builtin_fn(&mut self) {}
+    /// Builtin functions are always disabled for Empty Context.
+    fn is_builtin_fn_disabled(&self) -> bool {
+        true
+    }
 }
 
 impl<'a> IterateVariablesContext<'a> for EmptyContext {
@@ -105,6 +117,7 @@ pub struct HashMapContext {
     variables: HashMap<String, Value>,
     #[cfg_attr(feature = "serde_support", serde(skip))]
     functions: HashMap<String, Function>,
+    without_builtin_fn: bool,
 }
 
 impl HashMapContext {
@@ -127,6 +140,14 @@ impl Context for HashMapContext {
                 identifier.to_string(),
             ))
         }
+    }
+
+    fn disable_builtin_fn(&mut self) {
+        self.without_builtin_fn = true;
+    }
+
+    fn is_builtin_fn_disabled(&self) -> bool {
+        self.without_builtin_fn
     }
 }
 

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -459,7 +459,9 @@ impl Operator {
                 let arguments = &arguments[0];
 
                 match context.call_function(identifier, arguments) {
-                    Err(EvalexprError::FunctionIdentifierNotFound(_)) => {
+                    Err(EvalexprError::FunctionIdentifierNotFound(_))
+                        if !context.is_builtin_fn_disabled() =>
+                    {
                         if let Some(builtin_function) = builtin_function(identifier) {
                             builtin_function.call(arguments)
                         } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2243,3 +2243,14 @@ fn test_negative_power() {
     assert_eq!(eval("(-3)^-2"), Ok(Value::Float(1.0 / 9.0)));
     assert_eq!(eval("-(3^-2)"), Ok(Value::Float(-1.0 / 9.0)));
 }
+
+#[test]
+fn test_disabling_builtin_fn() {
+    let mut context = HashMapContext::new();
+    // Built in functions are enabled by default.
+    assert_eq!(eval_with_context("max(1,3)",&context),Ok(Value::from(3)));
+    // Disabling builtin function in Context.
+    context.disable_builtin_fn();
+    // Builting functions are disabled and using them returns Error.
+    assert_eq!(eval_with_context("max(1,3)",&context),Err(EvalexprError::FunctionIdentifierNotFound(String::from("max"))));
+}


### PR DESCRIPTION
# 112- disabling built-in functions

Builtin functions can be disabled in context.

## Description

In the context, Builtin functions can be disabled. If builtin functions are called, it returns Error. 

List here your changes

- I added the method to disable builtin functions.


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, Linux compatible

