### PR TITLE
add hex integer literal parsing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ regex = { version = "1.5.5", optional = true}
 serde = { version = "1.0.133", optional = true}
 serde_derive = { version = "1.0.133", optional = true}
 rand = { version = "0.8.5", optional = true}
+num-traits = "0.2.15"
 
 [features]
 serde_support = ["serde", "serde_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ regex = { version = "1.5.5", optional = true}
 serde = { version = "1.0.133", optional = true}
 serde_derive = { version = "1.0.133", optional = true}
 rand = { version = "0.8.5", optional = true}
-num-traits = "0.2.15"
 
 [features]
 serde_support = ["serde", "serde_derive"]

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -348,7 +348,7 @@ fn partial_tokens_to_tokens(mut tokens: &[PartialToken]) -> EvalexprResult<Vec<T
                 },
                 PartialToken::Literal(literal) => {
                     cutoff = 1;
-                    if let Ok(number) = literal.parse::<IntType>() {
+                    if let Ok(number) = literal.parse_dec_or_hex::<IntType>() {
                         Some(Token::Int(number))
                     } else if let Ok(number) = literal.parse::<FloatType>() {
                         Some(Token::Float(number))
@@ -440,6 +440,21 @@ fn partial_tokens_to_tokens(mut tokens: &[PartialToken]) -> EvalexprResult<Vec<T
 
 pub(crate) fn tokenize(string: &str) -> EvalexprResult<Vec<Token>> {
     partial_tokens_to_tokens(&str_to_partial_tokens(string)?)
+}
+
+/// Helper trait to parse strings to integer from both decimal or hex
+trait ParseDecOrHex {
+    fn parse_dec_or_hex<T: num_traits::Num>(&self) -> Result<T, T::FromStrRadixErr>;
+}
+
+impl ParseDecOrHex for str {
+    fn parse_dec_or_hex<T: num_traits::Num>(&self) -> Result<T, T::FromStrRadixErr> {
+        if self.starts_with("0x") {
+            T::from_str_radix(&self[2..], 16)
+        } else {
+            T::from_str_radix(&self, 10)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -443,10 +443,10 @@ pub(crate) fn tokenize(string: &str) -> EvalexprResult<Vec<Token>> {
 }
 
 fn parse_dec_or_hex(literal: &str) -> Result<IntType, std::num::ParseIntError> {
-    if literal.starts_with("0x") {
-        IntType::from_str_radix(&literal[2..], 16)
+    if let Some(literal) = literal.strip_prefix("0x") {
+        IntType::from_str_radix(literal, 16)
     } else {
-        IntType::from_str_radix(&literal, 10)
+        IntType::from_str_radix(literal, 10)
     }
 }
 

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -348,7 +348,7 @@ fn partial_tokens_to_tokens(mut tokens: &[PartialToken]) -> EvalexprResult<Vec<T
                 },
                 PartialToken::Literal(literal) => {
                     cutoff = 1;
-                    if let Ok(number) = literal.parse_dec_or_hex::<IntType>() {
+                    if let Ok(number) = parse_dec_or_hex(&literal) {
                         Some(Token::Int(number))
                     } else if let Ok(number) = literal.parse::<FloatType>() {
                         Some(Token::Float(number))
@@ -442,18 +442,11 @@ pub(crate) fn tokenize(string: &str) -> EvalexprResult<Vec<Token>> {
     partial_tokens_to_tokens(&str_to_partial_tokens(string)?)
 }
 
-/// Helper trait to parse strings to integer from both decimal or hex
-trait ParseDecOrHex {
-    fn parse_dec_or_hex<T: num_traits::Num>(&self) -> Result<T, T::FromStrRadixErr>;
-}
-
-impl ParseDecOrHex for str {
-    fn parse_dec_or_hex<T: num_traits::Num>(&self) -> Result<T, T::FromStrRadixErr> {
-        if self.starts_with("0x") {
-            T::from_str_radix(&self[2..], 16)
-        } else {
-            T::from_str_radix(&self, 10)
-        }
+fn parse_dec_or_hex(literal: &str) -> Result<IntType, std::num::ParseIntError> {
+    if literal.starts_with("0x") {
+        IntType::from_str_radix(&literal[2..], 16)
+    } else {
+        IntType::from_str_radix(&literal, 10)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2296,4 +2296,9 @@ fn test_builtin_functions_context() {
 fn test_hex() {
     assert_eq!(eval("0x3"), Ok(Value::Int(3)));
     assert_eq!(eval("0xFF"), Ok(Value::Int(255)));
+    assert_eq!(eval("-0xFF"), Ok(Value::Int(-255)));
+    assert_eq!(
+        eval("0x"),
+        Err(EvalexprError::VariableIdentifierNotFound("0x".into()))
+    );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2291,3 +2291,9 @@ fn test_builtin_functions_context() {
         )))
     );
 }
+
+#[test]
+fn test_hex() {
+    assert_eq!(eval("0x3"), Ok(Value::Int(3)));
+    assert_eq!(eval("0xFF"), Ok(Value::Int(255)));
+}


### PR DESCRIPTION
This PR implements parsing integer literals as both decimal and hex (`1234` and `0x1234`).
~~It adds `num_traits` as dependency, but that's a very light one.~~