### PR TITLE
Add mutable iteration over identifiers

### DIFF
--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -76,6 +76,36 @@ impl Node {
         })
     }
 
+    /// Returns an iterator over all identifiers in this expression, allowing mutation.
+    /// Each occurrence of an identifier is returned separately.
+    /// # Examples
+    ///
+    /// ```rust
+    /// use evalexpr::*;
+    ///
+    /// let mut tree = build_operator_tree("a + b + c * f()").unwrap(); // Do proper error handling here
+    ///
+    /// for identifier in tree.iter_identifiers_mut() {
+    ///     *identifier = String::from("x");
+    /// }
+    ///
+    /// let mut iter = tree.iter_identifiers();
+    ///
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter_identifiers_mut(&mut self) -> impl Iterator<Item = &mut String> {
+        self.iter_operator_mut().filter_map(|operator| match operator {
+            Operator::VariableIdentifierWrite { identifier }
+            | Operator::VariableIdentifierRead { identifier }
+            | Operator::FunctionIdentifier { identifier } => Some(identifier),
+            _ => None
+        })
+    }
+
     /// Returns an iterator over all variable identifiers in this expression.
     /// Each occurrence of a variable identifier is returned separately.
     ///
@@ -95,6 +125,36 @@ impl Node {
         self.iter().filter_map(|node| match node.operator() {
             Operator::VariableIdentifierWrite { identifier }
             | Operator::VariableIdentifierRead { identifier } => Some(identifier.as_str()),
+            _ => None,
+        })
+    }
+
+    /// Returns an iterator over all variable identifiers in this expression, allowing mutation.
+    /// Each occurrence of a variable identifier is returned separately.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use evalexpr::*;
+    ///
+    /// let mut tree = build_operator_tree("a + b + c * f()").unwrap(); // Do proper error handling here
+    ///
+    /// for identifier in tree.iter_variable_identifiers_mut() {
+    ///     *identifier = String::from("x");
+    /// }
+    ///
+    /// let mut iter = tree.iter_identifiers();
+    ///
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("f"));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter_variable_identifiers_mut(&mut self) -> impl Iterator<Item = &mut String> {
+        self.iter_operator_mut().filter_map(|operator| match operator {
+            Operator::VariableIdentifierWrite { identifier }
+            | Operator::VariableIdentifierRead { identifier } => Some(identifier),
             _ => None,
         })
     }
@@ -121,6 +181,36 @@ impl Node {
         })
     }
 
+    /// Returns an iterator over all read variable identifiers in this expression, allowing mutation.
+    /// Each occurrence of a variable identifier is returned separately.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use evalexpr::*;
+    ///
+    /// let mut tree = build_operator_tree("d = a + f(b + c)").unwrap(); // Do proper error handling here
+    ///
+    /// for identifier in tree.iter_read_variable_identifiers_mut() {
+    ///     *identifier = String::from("x");
+    /// }
+    ///
+    /// let mut iter = tree.iter_identifiers();
+    ///
+    /// assert_eq!(iter.next(), Some("d"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("f"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter_read_variable_identifiers_mut(&mut self) -> impl Iterator<Item = &mut String> {
+        self.iter_operator_mut().filter_map(|operator| match operator {
+            Operator::VariableIdentifierRead { identifier } => Some(identifier),
+            _ => None,
+        })
+    }
+
     /// Returns an iterator over all write variable identifiers in this expression.
     /// Each occurrence of a variable identifier is returned separately.
     ///
@@ -141,6 +231,36 @@ impl Node {
         })
     }
 
+    /// Returns an iterator over all write variable identifiers in this expression, allowing mutation.
+    /// Each occurrence of a variable identifier is returned separately.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use evalexpr::*;
+    ///
+    /// let mut tree = build_operator_tree("d = a + f(b + c)").unwrap(); // Do proper error handling here
+    ///
+    /// for identifier in tree.iter_write_variable_identifiers_mut() {
+    ///     *identifier = String::from("x");
+    /// }
+    ///
+    /// let mut iter = tree.iter_identifiers();
+    ///
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("a"));
+    /// assert_eq!(iter.next(), Some("f"));
+    /// assert_eq!(iter.next(), Some("b"));
+    /// assert_eq!(iter.next(), Some("c"));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter_write_variable_identifiers_mut(&mut self) -> impl Iterator<Item = &mut String> {
+        self.iter_operator_mut().filter_map(|operator| match operator {
+            Operator::VariableIdentifierWrite { identifier } => Some(identifier),
+            _ => None,
+        })
+    }
+
     /// Returns an iterator over all function identifiers in this expression.
     /// Each occurrence of a function identifier is returned separately.
     ///
@@ -157,6 +277,36 @@ impl Node {
     pub fn iter_function_identifiers(&self) -> impl Iterator<Item = &str> {
         self.iter().filter_map(|node| match node.operator() {
             Operator::FunctionIdentifier { identifier } => Some(identifier.as_str()),
+            _ => None,
+        })
+    }
+
+    /// Returns an iterator over all function identifiers in this expression, allowing mutation.
+    /// Each occurrence of a variable identifier is returned separately.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use evalexpr::*;
+    ///
+    /// let mut tree = build_operator_tree("d = a + f(b + c)").unwrap(); // Do proper error handling here
+    ///
+    /// for identifier in tree.iter_function_variable_identifiers_mut() {
+    ///     *identifier = String::from("x");
+    /// }
+    ///
+    /// let mut iter = tree.iter_identifiers();
+    ///
+    /// assert_eq!(iter.next(), Some("d"));
+    /// assert_eq!(iter.next(), Some("a"));
+    /// assert_eq!(iter.next(), Some("x"));
+    /// assert_eq!(iter.next(), Some("b"));
+    /// assert_eq!(iter.next(), Some("c"));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter_function_variable_identifiers_mut(&mut self) -> impl Iterator<Item = &mut String> {
+        self.iter_operator_mut().filter_map(|operator| match operator {
+            Operator::FunctionIdentifier { identifier } => Some(identifier),
             _ => None,
         })
     }


### PR DESCRIPTION
I have an application that could benefit a lot by iterating over identifiers mutably. This PR adds mutable iterators that parallel the existing immutable ones.

I think iterating mutably over *nodes* isn't possible, since they're nested; this gets around that by implementing iter_operator_mut() instead of iter_mut() as the underlying iterator.