### PR TITLE
New Feature: comments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,21 @@ Here are some examples and counter-examples on expressions that are interpreted 
 
 Functions have a precedence of 190.
 
+### Comments
+
+Both C like comments are supported.
+
+```rust
+use evalexpr::*;
+
+assert_eq!(eval("1 + /* inline comment */ 2"), Ok(Value::from(3)));
+assert_eq!(eval("
+    a = 1;
+    // line comment
+    a + 2
+    "), Ok(Value::from(3)));
+```
+
 ### [Serde](https://serde.rs)
 
 To use this crate with serde, the `serde_support` feature flag has to be set.

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -260,6 +260,41 @@ fn parse_string_literal<Iter: Iterator<Item = char>>(
     Err(EvalexprError::UnmatchedDoubleQuote)
 }
 
+fn try_skip_comment(iter: &mut std::iter::Peekable<std::str::Chars<'_>>) -> EvalexprResult<bool> {
+    let mut matched = false;
+    if let Some(lookahead) = iter.peek() {
+        if *lookahead == '/' {
+            matched = true;
+            iter.next();
+            // line comment
+            while let Some(c) = iter.next() {
+                if c == '\n' {
+                    break;
+                }
+            }
+        } else if *lookahead == '*' {
+            // inline commment
+            iter.next();
+            while let Some(c) = iter.next() {
+                if let Some(next) = iter.peek() {
+                    if c == '*' && *next == '/' {
+                        matched = true;
+                        iter.next();
+                        break;
+                    }
+                }
+            }
+            if !matched {
+                return Err(EvalexprError::CustomMessage(
+                    "unmatched inline comment".into(),
+                ));
+            }
+        }
+    }
+
+    Ok(matched)
+}
+
 /// Converts a string to a vector of partial tokens.
 fn str_to_partial_tokens(string: &str) -> EvalexprResult<Vec<PartialToken>> {
     let mut result = Vec::new();
@@ -270,6 +305,12 @@ fn str_to_partial_tokens(string: &str) -> EvalexprResult<Vec<PartialToken>> {
             result.push(parse_string_literal(&mut iter)?);
         } else {
             let partial_token = char_to_partial_token(c);
+
+            if let PartialToken::Slash = partial_token {
+                if try_skip_comment(&mut iter)? {
+                    continue;
+                }
+            }
 
             let if_let_successful =
                 if let (Some(PartialToken::Literal(last)), PartialToken::Literal(literal)) =
@@ -470,6 +511,28 @@ mod tests {
         let token_string =
             "+ - * / % ^ == != > < >= <= && || ! ( ) = += -= *= /= %= ^= &&= ||= , ; ";
         let tokens = tokenize(token_string).unwrap();
+        let mut result_string = String::new();
+
+        for token in tokens {
+            write!(result_string, "{} ", token).unwrap();
+        }
+
+        assert_eq!(token_string, result_string);
+    }
+
+    #[test]
+    fn test_skip_comment() {
+        let token_string =
+            "+ - * / % ^ == != > < >= <= && || ! ( ) = += -= *= /= %= ^= &&= ||= , ; ";
+
+        let token_string_with_comments = r"+ - * / % ^ == != > 
+            < >= <= && /* inline comment */ || ! ( ) 
+            = += -= *= /= %= ^=
+            // line comment
+            &&= ||= , ; 
+            ";
+
+        let tokens = tokenize(token_string_with_comments).unwrap();
         let mut result_string = String::new();
 
         for token in tokens {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2312,3 +2312,27 @@ fn test_broken_string() {
         Err(EvalexprError::UnmatchedDoubleQuote)
     );
 }
+
+#[test]
+fn test_comments() {
+    assert_eq!(
+        eval(
+            "
+            // input
+            a = 1;  // assignment
+            // output
+            a + 2  // add"
+        ),
+        Ok(Value::Int(3))
+    );
+
+    assert_eq!(
+        eval("1 % 4 + /*inline comment*/ 6 /*END*/"),
+        Ok(Value::Int(7))
+    );
+
+    assert_eq!(
+        eval("/* begin */ 10 /* middle */ + 5 /* end */ + 6 // DONE"),
+        Ok(Value::Int(21))
+    );
+}


### PR DESCRIPTION
Hi Author

Now add feature to support C like comments,  thanks! 

**Example:**
```rust

#[test]
fn test_comments() {
    assert_eq!(
        eval(
            "
            // input
            a = 1;  // assignment
            // output
            a + 2  // add"
        ),
        Ok(Value::Int(3))
    );

    assert_eq!(
        eval("1 % 4 + /*inline comment*/ 6 /*END*/"),
        Ok(Value::Int(7))
    );

    assert_eq!(
        eval("/* begin */ 10 /* middle */ + 5 /* end */ + 6 // DONE"),
        Ok(Value::Int(21))
    );
}

```