### PR TITLE
Added clear method on HashMapContext's variables and functions fields.

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -185,6 +185,16 @@ impl HashMapContext {
     pub fn new() -> Self {
         Default::default()
     }
+
+    /// Clears the [variables] HashMap so it can re-populated if needed
+    pub fn clear_variables_map(&mut self) {
+        self.variables.clear()
+    }
+
+    /// Clears the [functions] HashMap so it can re-populated if needed
+    pub fn clear_functions_map(&mut self) {
+        self.functions.clear()
+    }
 }
 
 impl Context for HashMapContext {


### PR DESCRIPTION
I've the below use case where numerous allocations are happening and hoping to reduce the impact of those re-allocations using the _clear_ method on the fields of `HashMapContext`:

There are 1000s of transactions with each transaction having about 40 fields. Let's say field 5 and field 30 are sent from source as optional Boolean type (`Option<bool>`), which would mean certain transaction could have a boolean value and other transactions would have null value. I cannot use a default boolean value here. Since once the `HashMapContext` variables are created, their types can no longer be changed. Therefore, I have re-initiate the HashMapContext ```let mut context = HashMapContext::new();``` after every transaction and does the re-allocation.