### PR TITLE
Convert Context::get_value to return owned Value

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -17,7 +17,7 @@ mod predefined;
 /// An immutable context.
 pub trait Context {
     /// Returns the value that is linked to the given identifier.
-    fn get_value(&self, identifier: &str) -> Option<&Value>;
+    fn get_value(&self, identifier: &str) -> Option<Value>;
 
     /// Calls the function that is linked to the given identifier with the given argument.
     /// If no function with the given identifier is found, this method returns `EvalexprError::FunctionIdentifierNotFound`.
@@ -82,7 +82,7 @@ pub trait GetFunctionContext: Context {
 pub struct EmptyContext;
 
 impl Context for EmptyContext {
-    fn get_value(&self, _identifier: &str) -> Option<&Value> {
+    fn get_value(&self, _identifier: &str) -> Option<Value> {
         None
     }
 
@@ -126,7 +126,7 @@ impl IterateVariablesContext for EmptyContext {
 pub struct EmptyContextWithBuiltinFunctions;
 
 impl Context for EmptyContextWithBuiltinFunctions {
-    fn get_value(&self, _identifier: &str) -> Option<&Value> {
+    fn get_value(&self, _identifier: &str) -> Option<Value> {
         None
     }
 
@@ -196,7 +196,7 @@ impl HashMapContext {
     ///
     /// let mut context = HashMapContext::new();
     /// context.set_value("abc".into(), "def".into()).unwrap();
-    /// assert_eq!(context.get_value("abc"), Some(&("def".into())));
+    /// assert_eq!(context.get_value("abc"), Some(("def".into())));
     /// context.clear_variables();
     /// assert_eq!(context.get_value("abc"), None);
     /// ```
@@ -220,7 +220,7 @@ impl HashMapContext {
     ///
     /// let mut context = HashMapContext::new();
     /// context.set_value("abc".into(), "def".into()).unwrap();
-    /// assert_eq!(context.get_value("abc"), Some(&("def".into())));
+    /// assert_eq!(context.get_value("abc"), Some(("def".into())));
     /// context.clear();
     /// assert_eq!(context.get_value("abc"), None);
     /// ```
@@ -231,8 +231,8 @@ impl HashMapContext {
 }
 
 impl Context for HashMapContext {
-    fn get_value(&self, identifier: &str) -> Option<&Value> {
-        self.variables.get(identifier)
+    fn get_value(&self, identifier: &str) -> Option<Value> {
+        self.variables.get(identifier).cloned()
     }
 
     fn call_function(&self, identifier: &str, argument: &Value) -> EvalexprResult<Value> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! assert_eq!(eval_empty_with_context_mut("a = 5.0", &mut context),
 //!            Err(EvalexprError::expected_int(Value::from(5.0))));
 //! // We can check which value the context stores for a like this
-//! assert_eq!(context.get_value("a"), Some(&Value::from(5)));
+//! assert_eq!(context.get_value("a"), Some(Value::from(5)));
 //! // And use the value in another expression like this
 //! assert_eq!(eval_int_with_context_mut("a = a + 2; a", &mut context), Ok(7));
 //! // It is also possible to save a bit of typing by using an operator-assignment operator
@@ -216,7 +216,7 @@
 //! assert_eq!(eval_empty_with_context_mut("a = 5.0", &mut context),
 //!            Err(EvalexprError::expected_int(5.0.into())));
 //! assert_eq!(eval_int_with_context("a", &context), Ok(5));
-//! assert_eq!(context.get_value("a"), Some(5.into()).as_ref());
+//! assert_eq!(context.get_value("a"), Some(5.into()));
 //! ```
 //!
 //! For each binary operator, there exists an equivalent operator-assignment operator.
@@ -307,8 +307,8 @@
 //! // We can write or overwrite variables in expressions...
 //! assert_eq!(eval_with_context_mut("a = 10; b = 1.0;", &mut context), Ok(().into()));
 //! // ...and read the value in code like this
-//! assert_eq!(context.get_value("a"), Some(&Value::from(10)));
-//! assert_eq!(context.get_value("b"), Some(&Value::from(1.0)));
+//! assert_eq!(context.get_value("a"), Some(Value::from(10)));
+//! assert_eq!(context.get_value("b"), Some(Value::from(1.0)));
 //! ```
 //!
 //! Contexts are also required for user-defined functions.

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -446,7 +446,7 @@ impl Operator {
             VariableIdentifierRead { identifier } => {
                 expect_operator_argument_amount(arguments.len(), 0)?;
 
-                if let Some(value) = context.get_value(identifier).cloned() {
+                if let Some(value) = context.get_value(identifier) {
                     Ok(value)
                 } else {
                     Err(EvalexprError::VariableIdentifierNotFound(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1695,7 +1695,7 @@ fn test_hashmap_context_clone_debug() {
     assert_eq!(format!("{:?}", &context), format!("{:?}", &cloned_context));
     assert_eq!(
         cloned_context.get_value("variable_five"),
-        Some(&Value::from(5))
+        Some(Value::from(5))
     );
     assert_eq!(
         eval_with_context("mult_3 2", &cloned_context),
@@ -2249,7 +2249,7 @@ fn assignment_lhs_is_identifier() {
 
     let mut context = HashMapContext::new();
     tree.eval_with_context_mut(&mut context).unwrap();
-    assert_eq!(context.get_value("a"), Some(&Value::Int(1)));
+    assert_eq!(context.get_value("a"), Some(Value::Int(1)));
 
     assert!(
         matches!(
@@ -2367,9 +2367,9 @@ fn test_comments() {
 fn test_clear() {
     let mut context = HashMapContext::new();
     context.set_value("abc".into(), "def".into()).unwrap();
-    assert_eq!(context.get_value("abc"), Some(&("def".into())));
+    assert_eq!(context.get_value("abc"), Some("def".into()));
     context.clear_functions();
-    assert_eq!(context.get_value("abc"), Some(&("def".into())));
+    assert_eq!(context.get_value("abc"), Some("def".into()));
     context.clear_variables();
     assert_eq!(context.get_value("abc"), None);
 


### PR DESCRIPTION
This is an API break (must go in 0.12).

Fixes #162.