### PR TITLE
fix: `str::from` builtin function with `String`

### DIFF
--- a/src/function/builtin.rs
+++ b/src/function/builtin.rs
@@ -268,7 +268,7 @@ pub fn builtin_function(identifier: &str) -> Option<Function> {
             Ok(Value::from(subject.trim()))
         })),
         "str::from" => Some(Function::new(|argument| {
-            Ok(Value::String(argument.to_string()))
+            Ok(Value::String(argument.str_from()))
         })),
         "str::substring" => Some(Function::new(|argument| {
             let args = argument.as_ranged_len_tuple(2..=3)?;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -335,12 +335,12 @@ mod tests {
                 Value::from("string"),
                 Value::from(3.3),
                 Value::from(3),
-                Value::from(TupleType::from([Value::from(42), Value::from(3.14),])),
+                Value::from(TupleType::from([Value::from(42), Value::from(4.2),])),
                 Value::from(()),
                 Value::from(true),
             ]))
             .str_from(),
-            r#"("string", 3.3, 3, (42, 3.14), (), true)"#
+            r#"("string", 3.3, 3, (42, 4.2), (), true)"#
         );
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -161,6 +161,19 @@ impl Value {
             value => Err(EvalexprError::expected_empty(value.clone())),
         }
     }
+
+    /// Returns a string for the `str::from` built-in function.
+    pub fn str_from(&self) -> String {
+        match self {
+            Value::String(v) => v.to_string(),
+            Value::Float(v) => v.to_string(),
+            Value::Int(v) => v.to_string(),
+            Value::Boolean(v) => v.to_string(),
+            Value::Tuple(_) => self.to_string(),
+            Value::Empty => String::from("()"),
+        }
+    }
+
 }
 
 impl From<String> for Value {
@@ -309,5 +322,25 @@ mod tests {
         assert!(Value::from(3.3).is_float());
         assert!(Value::from(true).is_boolean());
         assert!(Value::from(TupleType::new()).is_tuple());
+    }
+
+    #[test]
+    fn test_value_str_from() {
+        assert_eq!(Value::from("string").str_from(), "string");
+        assert_eq!(Value::from(3.3).str_from(), "3.3");
+        assert_eq!(Value::from(3).str_from(), "3");
+        assert_eq!(Value::from(true).str_from(), "true");
+        assert_eq!(Value::from(()).str_from(), "()");
+        assert_eq!(Value::from(TupleType::from([
+            Value::from("string"),
+            Value::from(3.3),
+            Value::from(3),
+            Value::from(TupleType::from([
+                    Value::from(42),
+                    Value::from(3.14),
+            ])),
+            Value::from(()),
+            Value::from(true),
+        ])).str_from(), r#"("string", 3.3, 3, (42, 3.14), (), true)"#);
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -173,7 +173,6 @@ impl Value {
             Value::Empty => String::from("()"),
         }
     }
-
 }
 
 impl From<String> for Value {
@@ -331,16 +330,17 @@ mod tests {
         assert_eq!(Value::from(3).str_from(), "3");
         assert_eq!(Value::from(true).str_from(), "true");
         assert_eq!(Value::from(()).str_from(), "()");
-        assert_eq!(Value::from(TupleType::from([
-            Value::from("string"),
-            Value::from(3.3),
-            Value::from(3),
+        assert_eq!(
             Value::from(TupleType::from([
-                    Value::from(42),
-                    Value::from(3.14),
-            ])),
-            Value::from(()),
-            Value::from(true),
-        ])).str_from(), r#"("string", 3.3, 3, (42, 3.14), (), true)"#);
+                Value::from("string"),
+                Value::from(3.3),
+                Value::from(3),
+                Value::from(TupleType::from([Value::from(42), Value::from(3.14),])),
+                Value::from(()),
+                Value::from(true),
+            ]))
+            .str_from(),
+            r#"("string", 3.3, 3, (42, 3.14), (), true)"#
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -506,8 +506,8 @@ fn test_builtin_functions() {
     );
     assert_eq!(eval("str::from(1.0)"), Ok(Value::String(String::from("1"))));
     assert_eq!(
-        eval("str::from(3.14)"),
-        Ok(Value::String(String::from("3.14")))
+        eval("str::from(4.2)"),
+        Ok(Value::String(String::from("4.2")))
     );
     assert_eq!(eval("str::from(1)"), Ok(Value::String(String::from("1"))));
     assert_eq!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -502,10 +502,13 @@ fn test_builtin_functions() {
     );
     assert_eq!(
         eval("str::from(\"a\")"),
-        Ok(Value::String(String::from("\"a\"")))
+        Ok(Value::String(String::from("a")))
     );
     assert_eq!(eval("str::from(1.0)"), Ok(Value::String(String::from("1"))));
+    assert_eq!(eval("str::from(3.14)"), Ok(Value::String(String::from("3.14"))));
     assert_eq!(eval("str::from(1)"), Ok(Value::String(String::from("1"))));
+    assert_eq!(eval("str::from(true)"), Ok(Value::String(String::from("true"))));
+    assert_eq!(eval(r#"str::from((1, "foo", , false))"#), Ok(Value::String(String::from(r#"(1, "foo", (), false)"#))));
     assert_eq!(
         eval("str::from(true)"),
         Ok(Value::String(String::from("true")))

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -505,10 +505,19 @@ fn test_builtin_functions() {
         Ok(Value::String(String::from("a")))
     );
     assert_eq!(eval("str::from(1.0)"), Ok(Value::String(String::from("1"))));
-    assert_eq!(eval("str::from(3.14)"), Ok(Value::String(String::from("3.14"))));
+    assert_eq!(
+        eval("str::from(3.14)"),
+        Ok(Value::String(String::from("3.14")))
+    );
     assert_eq!(eval("str::from(1)"), Ok(Value::String(String::from("1"))));
-    assert_eq!(eval("str::from(true)"), Ok(Value::String(String::from("true"))));
-    assert_eq!(eval(r#"str::from((1, "foo", , false))"#), Ok(Value::String(String::from(r#"(1, "foo", (), false)"#))));
+    assert_eq!(
+        eval("str::from(true)"),
+        Ok(Value::String(String::from("true")))
+    );
+    assert_eq!(
+        eval(r#"str::from((1, "foo", , false))"#),
+        Ok(Value::String(String::from(r#"(1, "foo", (), false)"#)))
+    );
     assert_eq!(
         eval("str::from(true)"),
         Ok(Value::String(String::from("true")))


### PR DESCRIPTION
- Added `from_str` function to `Value` that is called by the `str::from` builtin function.
- `from_str` does not add quotation marks around an input string. `str::from("foo")` returns `foo` instead of `"foo"` as before.
- Choice has been made to keep the use of `Value::to_string` formatting for `Value::Tuple` variant. Therefore, `str::from((42, false, "foo"))` returns `(42, false, "foo")`