### PR TITLE
Add a method to combine compiled trees together

### DIFF
--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -150,6 +150,7 @@ impl<NumericTypes: EvalexprNumericTypes> fmt::Display for EvalexprError<NumericT
                 int
             ),
             RandNotEnabled => write!(f, "The feature 'rand' must be enabled to use randomness"),
+            UnsuitableOperator(operator) => write!(f, "Unsuitable operator used: {operator}"),
             CustomMessage(message) => write!(f, "Error: {}", message),
         }
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -246,6 +246,9 @@ pub enum EvalexprError<NumericTypes: EvalexprNumericTypes = DefaultNumericTypes>
     /// The feature `rand` is not enabled, but required for the used function.
     RandNotEnabled,
 
+    /// An unsuitable Operator was used
+    UnsuitableOperator(Operator<NumericTypes>),
+
     /// A custom error explained by its message.
     CustomMessage(String),
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -6,7 +6,7 @@ use crate::{
         TupleType,
     },
     Context, ContextWithMutableVariables, EmptyType, EvalexprError, EvalexprResult, HashMapContext,
-    Node, Value, EMPTY_VALUE,
+    Node, Operator, Value, EMPTY_VALUE,
 };
 
 /// Evaluate the given expression string.
@@ -356,4 +356,21 @@ pub fn eval_empty_with_context_mut<C: ContextWithMutableVariables>(
         Ok(value) => Err(EvalexprError::expected_empty(value)),
         Err(error) => Err(error),
     }
+}
+
+/// Combined two parsed expression trees around an operator
+/// ```
+///use evalexpr::{build_operator_tree, combine_trees, eval, Operator};
+///let expr_1 = build_operator_tree("42/2").unwrap();
+///let expr_2 = build_operator_tree("34*5").unwrap();
+///
+///let combined = combine_trees(expr_1, expr_2, Operator::Add).unwrap();
+///assert_eq!(combined.eval(), eval("(42/2)+(34*5)"))
+/// ```
+pub fn combine_trees<NumericTypes: EvalexprNumericTypes>(
+    a: Node<NumericTypes>,
+    b: Node<NumericTypes>,
+    operator: Operator<NumericTypes>,
+) -> EvalexprResult<Node<NumericTypes>, NumericTypes> {
+    tree::combine_trees(a, b, operator)
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -973,3 +973,39 @@ pub(crate) fn tokens_to_operator_tree<NumericTypes: EvalexprNumericTypes>(
         Err(EvalexprError::UnmatchedRBrace)
     }
 }
+
+/// combine two trees with a specific binary+ operator.
+pub(crate) fn combine_trees<NumericTypes: EvalexprNumericTypes>(
+    a: Node<NumericTypes>,
+    b: Node<NumericTypes>,
+    operator: Operator<NumericTypes>,
+) -> EvalexprResult<Node<NumericTypes>, NumericTypes> {
+    if operator.is_unary() {
+        return Err(EvalexprError::UnsuitableOperator(operator));
+    }
+
+    let mut node: Node<NumericTypes> = Node::new(operator);
+
+    node.children.push(extract_root(a)?);
+    node.children.push(extract_root(b)?);
+
+    let mut root = Node::root_node();
+
+    root.children.push(node);
+
+    Ok(root)
+}
+
+/// extract root
+fn extract_root<NumericTypes: EvalexprNumericTypes>(
+    a: Node<NumericTypes>,
+) -> EvalexprResult<Node<NumericTypes>, NumericTypes> {
+    if a.operator == Operator::RootNode {
+        Ok(a)
+    } else {
+        a.children
+            .into_iter()
+            .next()
+            .map_or_else(|| Err(EvalexprError::OutOfBoundsAccess), Ok)
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2610,3 +2610,18 @@ fn test_node_mutable_access() {
     assert_eq!(node.children_mut().len(), 1);
     assert_eq!(*node.operator_mut(), Operator::RootNode);
 }
+
+#[test]
+fn test_tree_combining() {
+    let a = build_operator_tree::<DefaultNumericTypes>("1").unwrap();
+    let b = build_operator_tree::<DefaultNumericTypes>("4").unwrap();
+
+    let combined = combine_trees(a.clone(), b, Operator::Add).unwrap();
+    assert_eq!(combined.eval(), Ok(Value::Int(5)));
+
+    let c = build_operator_tree::<DefaultNumericTypes>("4+2").unwrap();
+    assert_eq!(
+        combine_trees(a, c, Operator::Add).unwrap().eval(),
+        Ok(Value::Int(7))
+    );
+}


### PR DESCRIPTION
Add an interface to combine two parsed expression tree in a new expression ready to eval.

The use-case for this  is to chain expressions programmatically without going back to manipulating initial strings, which I required for my program.

-------------

* [x] I publish this contribution under the [MIT License](https://opensource.org/license/mit).
