### PR TITLE
Add support for tuple operations

### DIFF
--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -50,11 +50,6 @@ impl<NumericTypes: EvalexprNumericTypes> fmt::Display for EvalexprError<NumericT
                 "Expected a Value::Tuple of length {}, but got {:?}.",
                 expected_length, actual
             ),
-            ExpectedSameLengthTuples { expected, actual } => write!(
-                f,
-                "Expected a the same length for tuples {:?} and {:?}.",
-                expected, actual
-            ),
             ExpectedRangedLengthTuple {
                 expected_length,
                 actual,

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -50,6 +50,11 @@ impl<NumericTypes: EvalexprNumericTypes> fmt::Display for EvalexprError<NumericT
                 "Expected a Value::Tuple of length {}, but got {:?}.",
                 expected_length, actual
             ),
+            ExpectedSameLengthTuples { expected, actual } => write!(
+                f,
+                "Expected a the same length for tuples {:?} and {:?}.",
+                expected, actual
+            ),
             ExpectedRangedLengthTuple {
                 expected_length,
                 actual,

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -93,14 +93,6 @@ pub enum EvalexprError<NumericTypes: EvalexprNumericTypes = DefaultNumericTypes>
         actual: Value<NumericTypes>,
     },
 
-    /// A tuple value of a certain length was expected.
-    ExpectedSameLengthTuples {
-        /// The tuple with expected length.
-        expected: Value<NumericTypes>,
-        /// The actual tuple with unexpected length.
-        actual: Value<NumericTypes>,
-    },
-
     /// A tuple value of a certain length range was expected.
     ExpectedRangedLengthTuple {
         /// The expected length range.
@@ -334,14 +326,6 @@ impl<NumericTypes: EvalexprNumericTypes> EvalexprError<NumericTypes> {
             expected_length: expected_len,
             actual,
         }
-    }
-
-    /// Constructs `EvalexprError::ExpectedSameLengthTuples {expected, actual}`.
-    pub fn expected_same_len_tuples(
-        expected: Value<NumericTypes>,
-        actual: Value<NumericTypes>,
-    ) -> Self {
-        EvalexprError::ExpectedSameLengthTuples { expected, actual }
     }
 
     /// Constructs `EvalexprError::ExpectedFixedLenTuple{expected_len, actual}`.

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -93,6 +93,14 @@ pub enum EvalexprError<NumericTypes: EvalexprNumericTypes = DefaultNumericTypes>
         actual: Value<NumericTypes>,
     },
 
+    /// A tuple value of a certain length was expected.
+    ExpectedSameLengthTuples {
+        /// The tuple with expected length.
+        expected: Value<NumericTypes>,
+        /// The actual tuple with unexpected length.
+        actual: Value<NumericTypes>,
+    },
+
     /// A tuple value of a certain length range was expected.
     ExpectedRangedLengthTuple {
         /// The expected length range.
@@ -326,6 +334,14 @@ impl<NumericTypes: EvalexprNumericTypes> EvalexprError<NumericTypes> {
             expected_length: expected_len,
             actual,
         }
+    }
+
+    /// Constructs `EvalexprError::ExpectedSameLengthTuples {expected, actual}`.
+    pub fn expected_same_len_tuples(
+        expected: Value<NumericTypes>,
+        actual: Value<NumericTypes>,
+    ) -> Self {
+        EvalexprError::ExpectedSameLengthTuples { expected, actual }
     }
 
     /// Constructs `EvalexprError::ExpectedFixedLenTuple{expected_len, actual}`.

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -203,70 +203,42 @@ impl<NumericTypes: EvalexprNumericTypes> Operator<NumericTypes> {
                     Ok(Value::Empty)
                 }
             },
-            Add | Sub => {
+            Add => {
                 expect_operator_argument_amount(arguments.len(), 2)?;
+                expect_number_or_string(&arguments[0])?;
+                expect_number_or_string(&arguments[1])?;
 
-                if let (Ok(a), Ok(b)) = (arguments[0].as_tuple(), arguments[1].as_tuple()) {
-                    if a.len() == b.len() {
-                        let mut result = Vec::with_capacity(a.len());
-                        for (a, b) in a.into_iter().zip(b) {
-                            result.push(self.eval(&[a, b], context)?);
-                        }
-
-                        Ok(Value::Tuple(result))
-                    } else {
-                        Err(EvalexprError::expected_same_len_tuples(
-                            arguments[0].clone(),
-                            arguments[1].clone(),
-                        ))
-                    }
+                if let (Ok(a), Ok(b)) = (arguments[0].as_string(), arguments[1].as_string()) {
+                    let mut result = String::with_capacity(a.len() + b.len());
+                    result.push_str(&a);
+                    result.push_str(&b);
+                    Ok(Value::String(result))
+                } else if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
+                    a.checked_add(&b).map(Value::Int)
+                } else if let (Ok(a), Ok(b)) = (arguments[0].as_number(), arguments[1].as_number())
+                {
+                    Ok(Value::Float(a + b))
                 } else {
-                    match self {
-                        Add => {
-                            expect_operator_argument_amount(arguments.len(), 2)?;
-                            expect_number_or_string(&arguments[0])?;
-                            expect_number_or_string(&arguments[1])?;
+                    Err(EvalexprError::wrong_type_combination(
+                        self.clone(),
+                        vec![
+                            arguments.get(0).unwrap().into(),
+                            arguments.get(1).unwrap().into(),
+                        ],
+                    ))
+                }
+            },
+            Sub => {
+                expect_operator_argument_amount(arguments.len(), 2)?;
+                arguments[0].as_number()?;
+                arguments[1].as_number()?;
 
-                            if let (Ok(a), Ok(b)) =
-                                (arguments[0].as_string(), arguments[1].as_string())
-                            {
-                                let mut result = String::with_capacity(a.len() + b.len());
-                                result.push_str(&a);
-                                result.push_str(&b);
-                                Ok(Value::String(result))
-                            } else if let (Ok(a), Ok(b)) =
-                                (arguments[0].as_int(), arguments[1].as_int())
-                            {
-                                a.checked_add(&b).map(Value::Int)
-                            } else if let (Ok(a), Ok(b)) =
-                                (arguments[0].as_number(), arguments[1].as_number())
-                            {
-                                Ok(Value::Float(a + b))
-                            } else {
-                                Err(EvalexprError::wrong_type_combination(
-                                    self.clone(),
-                                    vec![
-                                        arguments.get(0).unwrap().into(),
-                                        arguments.get(1).unwrap().into(),
-                                    ],
-                                ))
-                            }
-                        },
-                        Sub => {
-                            expect_operator_argument_amount(arguments.len(), 2)?;
-                            arguments[0].as_number()?;
-                            arguments[1].as_number()?;
-
-                            if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
-                                a.checked_sub(&b).map(Value::Int)
-                            } else {
-                                Ok(Value::Float(
-                                    arguments[0].as_number()? - arguments[1].as_number()?,
-                                ))
-                            }
-                        },
-                        _ => unreachable!(),
-                    }
+                if let (Ok(a), Ok(b)) = (arguments[0].as_int(), arguments[1].as_int()) {
+                    a.checked_sub(&b).map(Value::Int)
+                } else {
+                    Ok(Value::Float(
+                        arguments[0].as_number()? - arguments[1].as_number()?,
+                    ))
                 }
             },
             Neg => {

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -198,10 +198,7 @@ impl<NumericTypes: EvalexprNumericTypes> Operator<NumericTypes> {
 
         // Check if we can do piecewise operations on tuples
         match self {
-            FunctionIdentifier { identifier: _ } => {
-                // Don't wrap function tuple operations
-            },
-            _ => match arguments {
+            Add | Sub | Neg | Mul | Div | And | Or | Not => match arguments {
                 [Value::Tuple(a_elements), Value::Tuple(b_elements)] => {
                     if a_elements.len() != b_elements.len() {
                         return Err(EvalexprError::expected_same_len_tuples(
@@ -226,6 +223,7 @@ impl<NumericTypes: EvalexprNumericTypes> Operator<NumericTypes> {
                 },
                 _ => {},
             },
+            _ => {},
         }
 
         match self {

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -208,7 +208,7 @@ impl<NumericTypes: EvalexprNumericTypes> Operator<NumericTypes> {
                     }
 
                     let mut computed = Vec::with_capacity(a_elements.len());
-                    for (a, b) in a_elements.into_iter().zip(b_elements) {
+                    for (a, b) in a_elements.iter().zip(b_elements) {
                         computed.push(self.eval(&[a.clone(), b.clone()], context)?);
                     }
 
@@ -217,7 +217,7 @@ impl<NumericTypes: EvalexprNumericTypes> Operator<NumericTypes> {
                 [Value::Tuple(elements)] => {
                     let mut computed = Vec::with_capacity(elements.len());
                     for element in elements {
-                        computed.push(self.eval(&[element.clone()], context)?);
+                        computed.push(self.eval(std::slice::from_ref(element), context)?);
                     }
                     return Ok(Value::Tuple(computed));
                 },

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1548,6 +1548,38 @@ fn test_tuple_definitions() {
 }
 
 #[test]
+fn test_tuple_operations() {
+    assert_eq!(
+        eval("(1, 2, 3) + (4, 5, 6)"),
+        Ok(Value::Tuple(vec![
+            Value::from_int(5),
+            Value::from_int(7),
+            Value::from_int(9),
+        ]))
+    );
+    assert_eq!(
+        eval("(6, 5, 4) - (1, 2, 3)"),
+        Ok(Value::Tuple(vec![
+            Value::from_int(5),
+            Value::from_int(3),
+            Value::from_int(1),
+        ]))
+    );
+
+    assert_eq!(
+        eval("(1, 2, 3) + (4, 5)"),
+        Err(EvalexprError::ExpectedSameLengthTuples {
+            expected: Value::Tuple(vec![
+                Value::from_int(1),
+                Value::from_int(2),
+                Value::from_int(3),
+            ]),
+            actual: Value::Tuple(vec![Value::from_int(4), Value::from_int(5),])
+        })
+    );
+}
+
+#[test]
 fn test_implicit_context() {
     assert_eq!(
         eval("a = 2 + 4 * 2; b = -5 + 3 * 5; a == b"),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1550,6 +1550,14 @@ fn test_tuple_definitions() {
 #[test]
 fn test_tuple_operations() {
     assert_eq!(
+        eval("!(false, true, true)"),
+        Ok(Value::Tuple(vec![
+            Value::Boolean(true),
+            Value::Boolean(false),
+            Value::Boolean(false),
+        ]))
+    );
+    assert_eq!(
         eval("(1, 2, 3) + (4, 5, 6)"),
         Ok(Value::Tuple(vec![
             Value::from_int(5),


### PR DESCRIPTION
Add support for `Add` and `Sub` operations on `Value::Tuple`.

* [x] I publish this contribution under the [MIT License](https://opensource.org/license/mit).
